### PR TITLE
Allow setting sizelimit when attaching file.

### DIFF
--- a/losetup/src/main.rs
+++ b/losetup/src/main.rs
@@ -32,7 +32,7 @@ fn attach(image: &str, loopdev: Option<&str>, offset: u64) {
         match loopdev {
             None => LoopControl::open().and_then(|lc| lc.next_free()),
             Some(dev) => LoopDevice::open(&dev),
-        }.and_then(|ld| ld.attach(&image, offset))
+        }.and_then(|ld| ld.attach(&image, offset, None))
     )
 }
 


### PR DESCRIPTION
Allow setting the `sizelimit` parameter when attaching a file to a loopback device.