### PR TITLE
Version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "loopdev"
 description = "Setup and control loop devices"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Michael Daffin <michael@daffin.io>"]
 license = "MIT"
 documentation = "https://docs.rs/loopdev"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ use loopdev::LoopControl;
 let lc = LoopControl::open().unwrap();
 let ld = lc.next_free().unwrap();
 
-println!("{}", ld.get_path().unwrap().display());
+println!("{}", ld.path().unwrap().display());
 
-ld.attach("test.img", 0).unwrap();
+ld.attach_file("test.img").unwrap();
 // ...
 ld.detach().unwrap();
 ```

--- a/losetup/Cargo.lock
+++ b/losetup/Cargo.lock
@@ -1,11 +1,3 @@
-[root]
-name = "losetup"
-version = "0.1.3"
-dependencies = [
- "clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "loopdev 0.1.3",
-]
-
 [[package]]
 name = "ansi_term"
 version = "0.10.2"
@@ -29,7 +21,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.28.0"
+version = "2.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -67,10 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "loopdev"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "losetup"
+version = "0.2.0"
+dependencies = [
+ "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "loopdev 0.2.0",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
-"checksum clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc34bf7d5d66268b466b9852bca925ec1d2650654dab4da081e63fd230145c2e"
+"checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"

--- a/losetup/Cargo.toml
+++ b/losetup/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Michael Daffin <michael@daffin.io>"]
 name = "losetup"
 version = "0.2.0"
+description = "Setup and control loopback devices"
 
 [dependencies]
 clap = "2.23.3"

--- a/losetup/Cargo.toml
+++ b/losetup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Daffin <michael@daffin.io>"]
 name = "losetup"
-version = "0.1.3"
+version = "0.2.0"
 
 [dependencies]
 clap = "2.23.3"

--- a/losetup/src/main.rs
+++ b/losetup/src/main.rs
@@ -33,6 +33,11 @@ fn detach(matches: &clap::ArgMatches) -> io::Result<()> {
     LoopDevice::open(loopdev)?.detach()
 }
 
+fn set_capacity(matches: &clap::ArgMatches) -> io::Result<()> {
+    let loopdev = matches.value_of("file").unwrap();
+    LoopDevice::open(loopdev)?.set_capacity()
+}
+
 fn list(matches: Option<&clap::ArgMatches>) -> io::Result<()> {
     let (_free, _used) = match matches {
         Some(matches) => (matches.is_present("free"), matches.is_present("used")),
@@ -61,6 +66,10 @@ fn main() {
             (about: "detach the loop device from the backing file")
             (@arg file: +required "The file to detach")
         )
+        (@subcommand setcapacity =>
+            (about: "inform the loop driver of a change in size of the backing file")
+            (@arg file: +required "The file to set the capacity of")
+        )
         (@subcommand list =>
             (about: "list the available loop devices")
             (@arg free: -f --free "find free devices")
@@ -72,6 +81,7 @@ fn main() {
         ("find", _) => find(),
         ("attach", Some(matches)) => attach(matches),
         ("detach", Some(matches)) => detach(matches),
+        ("setcapacity", Some(matches)) => set_capacity(matches),
         (_, matches) => list(matches),
     };
 

--- a/losetup/src/main.rs
+++ b/losetup/src/main.rs
@@ -2,87 +2,81 @@
 extern crate clap;
 extern crate loopdev;
 
-use std::io::Write;
+use std::io::{self, Write};
 use std::process::exit;
 use loopdev::{LoopControl, LoopDevice};
 
-macro_rules! exit_on_error {
-    ($e:expr) => ({match $e {
-            Ok(d) => d,
-            Err(err) => {
-                writeln!(&mut std::io::stderr(), "{}", err).unwrap();
-                exit(1)
-            },
-        }
-    })
+fn find() -> io::Result<()> {
+    let loopdev = LoopControl::open()?.next_free()?;
+    println!("{}", loopdev.path().unwrap().display());
+    Ok(())
 }
 
-fn find() {
-    match LoopControl::open().and_then(|lc| lc.next_free()) {
-        Ok(ld) => println!("{}", ld.path().unwrap().display()),
-        Err(err) => {
-            writeln!(&mut std::io::stderr(), "{}", err).unwrap();
-            exit(1)
-        }
+fn attach(matches: &clap::ArgMatches) -> io::Result<()> {
+    let quite = matches.is_present("quite");
+    let image = matches.value_of("image").unwrap();
+    let offset = value_t!(matches.value_of("offset"), u64).unwrap_or(0);
+    let sizelimit = value_t!(matches.value_of("sizelimit"), u64).unwrap_or(0);
+    let loopdev = match matches.value_of("loopdev") {
+        Some(loopdev) => LoopDevice::open(&loopdev)?,
+        None => LoopControl::open().and_then(|lc| lc.next_free())?,
+    };
+    loopdev.attach_with_sizelimit(&image, offset, sizelimit)?;
+    if !quite {
+        println!("{}", loopdev.path().unwrap().display());
     }
+    Ok(())
 }
 
-fn attach(image: &str, loopdev: Option<&str>, offset: u64, sizelimit: u64) {
-    exit_on_error!(match loopdev {
-            None => LoopControl::open().and_then(|lc| lc.next_free()),
-            Some(dev) => LoopDevice::open(&dev),
-        }
-        .and_then(|ld| ld.attach_with_sizelimit(&image, offset, sizelimit)))
+fn detach(matches: &clap::ArgMatches) -> io::Result<()> {
+    let loopdev = matches.value_of("file").unwrap();
+    LoopDevice::open(loopdev)?.detach()
 }
 
-fn detach(dev: &str) {
-    exit_on_error!(LoopDevice::open(dev).and_then(|ld| ld.detach()))
-}
-
-fn list(_free: bool, _used: bool) {
+fn list(matches: Option<&clap::ArgMatches>) -> io::Result<()> {
+    let (_free, _used) = match matches {
+        Some(matches) => (matches.is_present("free"), matches.is_present("used")),
+        None => (false, false),
+    };
     unimplemented!();
 }
 
 fn main() {
     let matches = clap_app!(losetup =>
-        (version: "0.1.2")
-        (author: "Michael Daffin <michael@daffin.io>")
-        (about: "Setup and control loop devices")
+        (version: crate_version!())
+        (author: crate_authors!())
+        (about: crate_description!())
         (@subcommand find =>
             (about: "find the next free loop device")
-	)
+        )
         (@subcommand attach =>
             (about: "attach the loop device to a backing file")
-	    (@arg image: +required "the backing file to attach")
-	    (@arg loopdev: "the loop device to attach")
+            (@arg image: +required "the backing file to attach")
+            (@arg loopdev: "the loop device to attach")
             (@arg offset: -o --offset +takes_value "the offset within the file to start at")
             (@arg sizelimit: -s --sizelimit +takes_value "the file is limited to this size")
-	)
+            (@arg quite: -q --quite "don't print the device name")
+        )
         (@subcommand detach =>
             (about: "detach the loop device from the backing file")
-	    (@arg file: +required "The file to detach")
-	)
+            (@arg file: +required "The file to detach")
+        )
         (@subcommand list =>
             (about: "list the available loop devices")
             (@arg free: -f --free "find free devices")
             (@arg used: -u --used "find used devices")
-	)
-    )
-        .get_matches();
+        )
+    ).get_matches();
 
-    if let Some(_) = matches.subcommand_matches("find") {
-        find();
-    } else if let Some(matches) = matches.subcommand_matches("attach") {
-        let image = matches.value_of("image").unwrap();
-        let loopdev = matches.value_of("loopdev");
-        attach(image,
-               loopdev,
-               value_t!(matches.value_of("offset"), u64).unwrap_or(0),
-               value_t!(matches.value_of("sizelimit"), u64).unwrap_or(0));
-    } else if let Some(matches) = matches.subcommand_matches("detach") {
-        let file = matches.value_of("file").unwrap();
-        detach(file);
-    } else {
-        list(matches.is_present("free"), matches.is_present("used"));
+    let result = match matches.subcommand() {
+        ("find", _) => find(),
+        ("attach", Some(matches)) => attach(matches),
+        ("detach", Some(matches)) => detach(matches),
+        (_, matches) => list(matches),
+    };
+
+    if let Err(err) = result {
+        writeln!(&mut std::io::stderr(), "{}", err).unwrap();
+        exit(1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,6 @@ impl LoopDevice {
     }
 
     /// Attach the loop device to a file starting at offset into the file.
-    ///
-    /// **Deprecated** use `attach_file`, `attach_with_offset` or `attach_with_size` instead.
     #[deprecated(since = "0.2.0", note = "use `attach_file` or `attach_with_offset` instead")]
     pub fn attach<P: AsRef<Path>>(&self, backing_file: P, offset: u64) -> io::Result<()> {
         self.attach_with_size(backing_file, offset, 0)
@@ -173,7 +171,13 @@ impl LoopDevice {
     }
 
     /// Get the path of the loop device.
+    #[deprecated(since = "0.2.0", note = "use `path` instead")]
     pub fn get_path(&self) -> Option<PathBuf> {
+        self.path()
+    }
+
+    /// Get the path of the loop device.
+    pub fn path(&self) -> Option<PathBuf> {
         let mut p = PathBuf::from("/proc/self/fd");
         p.push(self.device.as_raw_fd().to_string());
         std::fs::read_link(&p).ok()
@@ -192,10 +196,11 @@ impl LoopDevice {
     pub fn detach(&self) -> io::Result<()> {
         unsafe {
             if ioctl(self.device.as_raw_fd() as c_int, LOOP_CLR_FD.into(), 0) < 0 {
-                return Err(io::Error::last_os_error());
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
             }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
A collection of changes for version 0.2.0

Since we had to change the api slightly and deprecate some methods a minor version bump is required.

- `attach` is now `attach_with_offset` and `attach_file` and `attach_with_sizelimit` have been added.
- `get_path` is now just `path` to better follow rusts naming conventions.

These methods will continue to exist until at least 0.3.0 but have been marked as deprecated.