### PR TITLE
Update env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 /Cargo.lock
 test.img
+*.rustfmt

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 /Cargo.lock
 test.img
 *.rustfmt
+.vagrant
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ rust:
 - nightly
 - beta
 - stable
-- 1.10.0
-- 1.9.0
+- 1.20.0
+- 1.19.0
+- 1.18.0
+- 1.17.0
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -22,3 +22,32 @@ ld.attach_file("test.img").unwrap();
 // ...
 ld.detach().unwrap();
 ```
+
+## Development
+
+### Running The Tests Locally
+
+Unfortinutly the tests require root only syscalls and thus must be run as root.
+There is little point in mocking out these syscalls as I want to test they
+actually function as expected and if they were to be mocked out then the tests
+would not really be testing anything useful.
+
+A vagrant file is provided that can be used to create an environment to safly
+run these tests locally as root. With [Vagrant] and [VirtualBox] installed you
+can do the following to run the tests.
+
+```bash
+vagrant up
+vagrant ssh
+sudo -i
+cd /vagrant
+cargo test
+```
+
+Note that the tests are built with root privllages, but since vagrant maps this
+directoy back to the host as your normal user there is minimal issues with
+this. At worst the vagrant box will become trashed and can be rebuilt in
+minutes.
+
+[vagrant]: https://www.vagrantup.com/docs/installation/
+[virtualbox]: https://www.virtualbox.org/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.provision "shell",
+    inline: <<-EOS
+      curl https://sh.rustup.rs -sSf | sh -s -- -y
+      fallocate -l 128M /tmp/test.img
+      mv /tmp/test.img /vagrant/
+EOS
+end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ const LOOP_SET_CAPACITY: u16 = 0x4C07;
 //const LOOP_CTL_REMOVE: u16 = 0x4C81;
 const LOOP_CTL_GET_FREE: u16 = 0x4C82;
 
-const LOOP_CONTROL: &'static str = "/dev/loop-control";
-const LOOP_PREFIX: &'static str = "/dev/loop";
+const LOOP_CONTROL: &str = "/dev/loop-control";
+const LOOP_PREFIX: &str = "/dev/loop";
 
 /// Interface to the loop control device: `/dev/loop-control`.
 #[derive(Debug)]


### PR DESCRIPTION
Updates the environment and fixes some clippy issues. This adds a Vagrantfile to make local development easier as the tests require root privileges to run (due to the privileged syscalls the application requires).

The minimum version of rust supported is now 1.17.0 from 1.9.0.