### PR TITLE
Bumps the version to 0.3.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "loopdev"
 description = "Setup and control loop devices"
-version = "0.2.0"
+version = "0.3.0-dev"
 authors = ["Michael Daffin <michael@daffin.io>"]
 license = "MIT"
 documentation = "https://docs.rs/loopdev"


### PR DESCRIPTION
A braking change was introduced and this is a reminder that a minimum version bump to 0.3.0 will be required for the next release. This also avoid confusion as to what version is being used if it is a -dev version then it will not be an offically released version.