### PR TITLE
Implement AsRawFd for LoopDevice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,12 @@ pub struct LoopDevice {
     device: File,
 }
 
+impl AsRawFd for LoopDevice {
+    fn as_raw_fd(&self) -> RawFd {
+        self.device.as_raw_fd()
+    }
+}
+
 impl LoopDevice {
     /// Opens a loop device.
     pub fn open<P: AsRef<Path>>(dev: P) -> io::Result<LoopDevice> {


### PR DESCRIPTION
This is required in order to use an ISO as a loopback device.

```rust
fn mount_iso_to_loopback<I: AsRawFd, L: AsRawFd>(
    iso: &I,
    loopback: &L
) -> io::Result<()> {
    let result = unsafe {
        libc::ioctl(
            loopback.as_raw_fd(),
            LOOP_SET_FD,
            iso.as_raw_fd()
        )
    };

    if result < 0 {
        Err(io::Error::last_os_error())
    } else {
        Ok(())
    }
}
```