### PR TITLE
Add cmd to install gcc on Vagrantfile in order to build libc crate

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell",
     inline: <<-EOS
       curl https://sh.rustup.rs -sSf | sh -s -- -y
+      apt install -y gcc
       fallocate -l 128M /tmp/test.img
       mv /tmp/test.img /vagrant/
 EOS


### PR DESCRIPTION
Building the project on Vagrant after running commands on README results in error for missing 'cc' linker when building libc. Installing gcc fixes this.