### PR TITLE
Android build, additional flags, AsRawFd, IntoRawFd, CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+runner = '.cargo/runner-x86_64-unknown-linux-gnu'

--- a/.cargo/runner-x86_64-unknown-linux-gnu
+++ b/.cargo/runner-x86_64-unknown-linux-gnu
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+binary_name=`basename $1`
+
+sudo -E --preserve-env=PATH $@

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ travis-ci = { repository = "serde-rs/serde" }
 errno = "0.2"
 libc = "0.2"
 
+[build-dependencies]
+bindgen = "0.58.1"
+
 [dev-dependencies]
 tempfile = "3.1.0"
 lazy_static = "1.3.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+extern crate bindgen;
+
+use bindgen::Builder;
+use std::{env::var, path::PathBuf};
+
+fn main() {
+    let bindings = Builder::default()
+        .header_contents("wrapper.h", "#include <linux/loop.h>")
+        .derive_default(true)
+        .generate()
+        .expect("Could not generate bindings");
+
+    let mut bindings_path = PathBuf::from(var("OUT_DIR").unwrap());
+    bindings_path.push("bindings.rs");
+    bindings
+        .write_to_file(&bindings_path)
+        .expect("Could not write bindings to file");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,31 +18,25 @@
 
 extern crate libc;
 
-use std::fs::File;
-use std::fs::Metadata;
-use std::fs::OpenOptions;
-
+use bindings::{
+    loop_info64, LOOP_CLR_FD, LOOP_CTL_GET_FREE, LOOP_SET_CAPACITY, LOOP_SET_DIRECT_IO,
+    LOOP_SET_FD, LOOP_SET_STATUS64,
+};
 use libc::{c_int, ioctl};
-use std::default::Default;
-use std::io;
-use std::os::unix::prelude::*;
-use std::path::{Path, PathBuf};
+use std::fs::{File, Metadata, OpenOptions};
+use std::{
+    default::Default,
+    io,
+    os::unix::prelude::*,
+    path::{Path, PathBuf},
+};
 
-// TODO support missing operations
-const LOOP_SET_FD: u16 = 0x4C00;
-const LOOP_CLR_FD: u16 = 0x4C01;
-const LOOP_SET_STATUS64: u16 = 0x4C04;
-//const LOOP_GET_STATUS64: u16 = 0x4C05;
-const LOOP_SET_CAPACITY: u16 = 0x4C07;
-const LOOP_SET_DIRECT_IO: u16 = 0x4C08;
-//const LOOP_SET_BLOCK_SIZE: u16 = 0x4C09;
-
-//const LOOP_CTL_ADD: u16 = 0x4C80;
-//const LOOP_CTL_REMOVE: u16 = 0x4C81;
-const LOOP_CTL_GET_FREE: u16 = 0x4C82;
-
-const LOOP_FLAG_READ_ONLY: u32 = 0x01;
-const LOOP_FLAG_AUTOCLEAR: u32 = 0x04;
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+#[allow(non_snake_case)]
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
 
 const LOOP_CONTROL: &str = "/dev/loop-control";
 #[cfg(not(target_os = "android"))]
@@ -144,7 +138,7 @@ impl LoopDevice {
         note = "use `loop.with().offset(offset).attach(file)` instead"
     )]
     pub fn attach<P: AsRef<Path>>(&self, backing_file: P, offset: u64) -> io::Result<()> {
-        let info = LoopInfo64 {
+        let info = loop_info64 {
             lo_offset: offset,
             ..Default::default()
         };
@@ -165,7 +159,7 @@ impl LoopDevice {
     /// # ld.detach().unwrap();
     /// ```
     pub fn attach_file<P: AsRef<Path>>(&self, backing_file: P) -> io::Result<()> {
-        let info = LoopInfo64 {
+        let info = loop_info64 {
             ..Default::default()
         };
 
@@ -182,7 +176,7 @@ impl LoopDevice {
         backing_file: P,
         offset: u64,
     ) -> io::Result<()> {
-        let info = LoopInfo64 {
+        let info = loop_info64 {
             lo_offset: offset,
             ..Default::default()
         };
@@ -201,7 +195,7 @@ impl LoopDevice {
         offset: u64,
         size_limit: u64,
     ) -> io::Result<()> {
-        let info = LoopInfo64 {
+        let info = loop_info64 {
             lo_offset: offset,
             lo_sizelimit: size_limit,
             ..Default::default()
@@ -210,11 +204,11 @@ impl LoopDevice {
         Self::attach_with_loop_info(self, backing_file, info)
     }
 
-    /// Attach the loop device to a file with loop_info.
+    /// Attach the loop device to a file with loop_info64.
     fn attach_with_loop_info(
         &self, // TODO should be mut? - but changing it is a breaking change
         backing_file: impl AsRef<Path>,
-        info: LoopInfo64,
+        info: loop_info64,
     ) -> io::Result<()> {
         let bf = OpenOptions::new()
             .read(true)
@@ -223,8 +217,8 @@ impl LoopDevice {
         self.attach_fd_with_loop_info(bf.as_raw_fd(), info)
     }
 
-    /// Attach the loop device to a fd with loop_info.
-    fn attach_fd_with_loop_info(&self, bf: impl AsRawFd, info: LoopInfo64) -> io::Result<()> {
+    /// Attach the loop device to a fd with loop_info64.
+    fn attach_fd_with_loop_info(&self, bf: impl AsRawFd, info: loop_info64) -> io::Result<()> {
         // Attach the file
         ioctl_to_error(unsafe {
             ioctl(
@@ -344,7 +338,7 @@ impl LoopDevice {
 /// ```
 pub struct AttachOptions<'d> {
     device: &'d mut LoopDevice,
-    info: LoopInfo64,
+    info: loop_info64,
     direct_io: bool,
 }
 
@@ -364,9 +358,9 @@ impl AttachOptions<'_> {
     /// Set read only flag
     pub fn read_only(mut self, read_only: bool) -> Self {
         if read_only {
-            self.info.lo_flags |= LOOP_FLAG_READ_ONLY;
+            self.info.lo_flags |= bindings::LO_FLAGS_READ_ONLY;
         } else {
-            self.info.lo_flags &= !LOOP_FLAG_READ_ONLY;
+            self.info.lo_flags &= !bindings::LO_FLAGS_READ_ONLY;
         }
         self
     }
@@ -374,9 +368,9 @@ impl AttachOptions<'_> {
     /// Set autoclear flag
     pub fn autoclear(mut self, read_only: bool) -> Self {
         if read_only {
-            self.info.lo_flags |= LOOP_FLAG_AUTOCLEAR;
+            self.info.lo_flags |= bindings::LO_FLAGS_AUTOCLEAR;
         } else {
-            self.info.lo_flags &= !LOOP_FLAG_AUTOCLEAR;
+            self.info.lo_flags &= !bindings::LO_FLAGS_AUTOCLEAR;
         }
         self
     }
@@ -415,44 +409,6 @@ impl AttachOptions<'_> {
             self.device.set_direct_io(self.direct_io)?;
         }
         Ok(())
-    }
-}
-
-// https://man7.org/linux/man-pages/man4/loop.4.html
-#[repr(C)]
-struct LoopInfo64 {
-    pub lo_device: u64,           // ioctl r/o
-    pub lo_inode: u64,            // ioctl r/o
-    pub lo_rdevice: u64,          // ioctl r/o
-    pub lo_offset: u64,           //
-    pub lo_sizelimit: u64,        // bytes, 0 == max available
-    pub lo_number: u32,           // ioctl r/o
-    pub lo_encrypt_type: u32,     //
-    pub lo_encrypt_key_size: u32, // ioctl w/o
-    pub lo_flags: u32,            // ioctl r/w (r/o before Linux 2.6.25)
-    pub lo_file_name: [u8; 64],   //
-    pub lo_crypt_name: [u8; 64],  //
-    pub lo_encrypt_key: [u8; 32], // ioctl w/o
-    pub lo_init: [u64; 2],        //
-}
-
-impl Default for LoopInfo64 {
-    fn default() -> Self {
-        Self {
-            lo_device: 0,
-            lo_inode: 0,
-            lo_rdevice: 0,
-            lo_offset: 0,
-            lo_sizelimit: 0,
-            lo_number: 0,
-            lo_encrypt_type: 0,
-            lo_encrypt_key_size: 0,
-            lo_flags: 0,
-            lo_file_name: [0; 64],
-            lo_crypt_name: [0; 64],
-            lo_encrypt_key: [0; 32],
-            lo_init: [0; 2],
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,10 @@ const LOOP_SET_CAPACITY: u16 = 0x4C07;
 const LOOP_CTL_GET_FREE: u16 = 0x4C82;
 
 const LOOP_CONTROL: &str = "/dev/loop-control";
+#[cfg(not(target_os = "android"))]
 const LOOP_PREFIX: &str = "/dev/loop";
+#[cfg(target_os = "android")]
+const LOOP_PREFIX: &str = "/dev/block/loop";
 
 /// Interface to the loop control device: `/dev/loop-control`.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,18 @@ impl LoopControl {
     }
 }
 
+impl AsRawFd for LoopControl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.dev_file.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for LoopControl {
+    fn into_raw_fd(self) -> RawFd {
+        self.dev_file.into_raw_fd()
+    }
+}
+
 /// Interface to a loop device ie `/dev/loop0`.
 #[derive(Debug)]
 pub struct LoopDevice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //!
-//! ```rust
+//! ```no_run
 //! use loopdev::LoopControl;
 //! let lc = LoopControl::open().unwrap();
 //! let ld = lc.next_free().unwrap();
@@ -70,7 +70,7 @@ impl LoopControl {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopControl;
     /// let lc = LoopControl::open().unwrap();
     /// let ld = lc.next_free().unwrap();
@@ -126,7 +126,7 @@ impl LoopDevice {
     ///
     /// Attach the device to a file.
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
     /// let mut ld = LoopDevice::open("/dev/loop3").unwrap();
     /// ld.with().part_scan(true).attach("test.img").unwrap();
@@ -160,7 +160,7 @@ impl LoopDevice {
     ///
     /// Attach the device to a file.
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
     /// let ld = LoopDevice::open("/dev/loop4").unwrap();
     /// ld.attach_file("test.img").unwrap();
@@ -279,7 +279,7 @@ impl LoopDevice {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
     /// let ld = LoopDevice::open("/dev/loop5").unwrap();
     /// # ld.attach_file("test.img").unwrap();
@@ -328,7 +328,7 @@ impl LoopDevice {
 ///
 /// Enable partition scanning on attach:
 ///
-/// ```rust
+/// ```no_run
 /// use loopdev::LoopDevice;
 /// let mut ld = LoopDevice::open("/dev/loop6").unwrap();
 /// ld.with()
@@ -340,7 +340,7 @@ impl LoopDevice {
 ///
 /// A 1MiB slice of the file located at 1KiB into the file.
 ///
-/// ```rust
+/// ```no_run
 /// use loopdev::LoopDevice;
 /// let mut ld = LoopDevice::open("/dev/loop7").unwrap();
 /// ld.with()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 extern crate libc;
 
 use std::fs::File;
+use std::fs::Metadata;
 use std::fs::OpenOptions;
 
 use libc::{c_int, ioctl};
@@ -250,6 +251,11 @@ impl LoopDevice {
         let mut p = PathBuf::from("/proc/self/fd");
         p.push(self.device.as_raw_fd().to_string());
         std::fs::read_link(&p).ok()
+    }
+
+    /// Get the device metadata
+    pub fn metadata(&self) -> io::Result<Metadata> {
+        self.device.metadata()
     }
 
     /// Detach a loop device from its backing file.

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,9 +1,11 @@
 use libc::fallocate;
 use serde::{Deserialize, Deserializer};
-use std::io;
-use std::os::unix::io::AsRawFd;
-use std::process::Command;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::{
+    io,
+    os::unix::io::AsRawFd,
+    process::Command,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 use tempfile::{NamedTempFile, TempPath};
 


### PR DESCRIPTION
This PR contains a couple of things I'd need in `loopdev`:

* Build for Android: Androids `bionic` differs in some ways from `glibc` and others. The path to loop devices is different. Add a `cfg` directive for `target_os = "android"` and not.
* Add flags: `read_only`, `autoclear` and `direct io`
* Expose the loop devices `Metadata`

On the way there I added `bindgen` in a `build.rs` to gather the bindings during the build. Vagrant refused to work in my setup so I run the tests locally and added a GH actions script. The tests were flaky in GH because (as we all know) the loopdev driver sometimes lazy and just return an `EBSY`. I replace one of the `losetup` calls with a call from this crate - works so far.

@mdaffin Let me know which of the above things can be merged. I can prepare dedicated and clean PRs for each (and work with my master in the meantime ;-)). I did the GH actions stuff just because I'm curious....there's not need to that.