### PR TITLE
Make LOOP_PREFIX target_os specific

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,10 @@ const LOOP_SET_CAPACITY: u16 = 0x4C07;
 const LOOP_CTL_GET_FREE: u16 = 0x4C82;
 
 const LOOP_CONTROL: &str = "/dev/loop-control";
+#[cfg(not(target_os = "android"))]
 const LOOP_PREFIX: &str = "/dev/loop";
+#[cfg(target_os = "android")]
+const LOOP_PREFIX: &str = "/dev/block/loop";
 
 /// Interface to the loop control device: `/dev/loop-control`.
 #[derive(Debug)]


### PR DESCRIPTION
Android system setup loop devices at `/dev/block/loop` instead of
`/dev/loop`. Add a `cfg` directive to that sets the `LOOP_PREFIX` for
`target_os = "android"` accordingly.