### PR TITLE
Implement AsRawFd and IntoRawFd for LoopControl and LoopDevice. Add `metadata`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,18 @@ impl LoopControl {
     }
 }
 
+impl AsRawFd for LoopControl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.dev_file.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for LoopControl {
+    fn into_raw_fd(self) -> RawFd {
+        self.dev_file.into_raw_fd()
+    }
+}
+
 /// Interface to a loop device ie `/dev/loop0`.
 #[derive(Debug)]
 pub struct LoopDevice {
@@ -95,6 +107,12 @@ pub struct LoopDevice {
 impl AsRawFd for LoopDevice {
     fn as_raw_fd(&self) -> RawFd {
         self.device.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for LoopDevice {
+    fn into_raw_fd(self) -> RawFd {
+        self.device.into_raw_fd()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@ use bindings::{
     loop_info64, LOOP_CLR_FD, LOOP_CTL_GET_FREE, LOOP_SET_CAPACITY, LOOP_SET_FD, LOOP_SET_STATUS64,
 };
 use libc::{c_int, ioctl};
-use std::fs::{File, OpenOptions};
 use std::{
     default::Default,
+    fs::{File, Metadata, OpenOptions},
     io,
     os::unix::prelude::*,
     path::{Path, PathBuf},
@@ -261,6 +261,11 @@ impl LoopDevice {
         let mut p = PathBuf::from("/proc/self/fd");
         p.push(self.device.as_raw_fd().to_string());
         std::fs::read_link(&p).ok()
+    }
+
+    /// Get the device metadata
+    pub fn metadata(&self) -> io::Result<Metadata> {
+        self.device.metadata()
     }
 
     /// Detach a loop device from its backing file.


### PR DESCRIPTION
Implement AsRawFd and IntoRawFd for LoopControl and LoopDevice
Getting the raw fd of loop control can be neccecary because the
`next_free` and `attach` operation is (unfortunately) not atomic. The fd
can be used to acquire a `flock`.

Add `IntoRawFd` for `LoopDevice`.
Add `metadata` to `LoopDevice`.