### PR TITLE
Disable most features of bindgen to reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ errno = "0.2"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.58.1"
+bindgen = { version = "0.58.1", default-features = false, features = ["runtime"] }
 
 [dev-dependencies]
 tempfile = "3.1.0"


### PR DESCRIPTION
By default, bindgen depends on everything needed to build the bindgen
command-line tool, such as clap and its various dependencies. Disable
default-features on bindgen and just enable the minimum required
features. This reduces loopdev's full dependency tree from 54 crates to
39 crates.