### PR TITLE
add support for musl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,9 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
 type IoctlRequest = libc::c_ulong;
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_env = "musl"))]
 type IoctlRequest = libc::c_int;
 
 const LOOP_CONTROL: &str = "/dev/loop-control";


### PR DESCRIPTION
`ioctl` has a different signature in `musl` compared to `libc`

**musl**: https://git.musl-libc.org/cgit/musl/tree/src/misc/ioctl.c?h=3f701faace7addc75d16dea8a6cd769fa5b3f260#n123
```
int ioctl(int fd, int req, ...);
```

**libc**: https://man7.org/linux/man-pages/man2/ioctl.2.html
```
int ioctl(int fd, unsigned long request, ...);
```

there seems to be identical conditional for `android`, so I just updated it to deal with `musl`
with this change it compiles on both `x86_64-unknown-linux-musl` and `x86_64-unknown-linux-gnu` but I haven't tested any other target
