### PR TITLE
Fix creating loopdevs with read-only backing files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,9 +193,10 @@ impl LoopDevice {
         backing_file: impl AsRef<Path>,
         info: loop_info64,
     ) -> io::Result<()> {
+        let write_access = (info.lo_flags & LO_FLAGS_READ_ONLY) == 0;
         let bf = OpenOptions::new()
             .read(true)
-            .write(true)
+            .write(write_access)
             .open(backing_file)?;
         self.attach_fd_with_loop_info(bf, info)
     }


### PR DESCRIPTION
Currently, when a new loopdev is created with LO_FLAGS_READ_ONLY set, the backing file is still opened in RW mode. This call fails when the user does not have write-permissions on the file (for example, the file is on a read-only filesystem). This patch checks for LO_FLAGS_READ_ONLY and opens the file without write mode if the flag is set.