### PR TITLE
riscv64gc support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ errno = "0.2.8"
 libc = "0.2.105"
 
 [build-dependencies]
-bindgen = { version = "0.59.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
Update `bindgen` to support riscv64gc.

Closes #46