### PR TITLE
Fix the AttachOptions.part_scan function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ extern crate libc;
 use bindings::LOOP_SET_DIRECT_IO;
 use bindings::{
     loop_info64, LOOP_CLR_FD, LOOP_CTL_GET_FREE, LOOP_SET_CAPACITY, LOOP_SET_FD, LOOP_SET_STATUS64,
-    LO_FLAGS_AUTOCLEAR, LO_FLAGS_READ_ONLY,
+    LO_FLAGS_AUTOCLEAR, LO_FLAGS_PARTSCAN, LO_FLAGS_READ_ONLY,
 };
 use libc::{c_int, ioctl};
 use std::{
@@ -385,9 +385,9 @@ impl AttachOptions<'_> {
     /// partition table parsing depends on sector sizes. The default is sector size is 512 bytes
     pub fn part_scan(mut self, enable: bool) -> Self {
         if enable {
-            self.info.lo_flags |= 1 << 4;
+            self.info.lo_flags |= LO_FLAGS_PARTSCAN;
         } else {
-            self.info.lo_flags &= u32::max_value() - (1 << 4);
+            self.info.lo_flags &= !LO_FLAGS_PARTSCAN;
         }
         self
     }


### PR DESCRIPTION
The function currently writes a value of 16 to lo_flags, but 16 is the value for LO_FLAGS_DIRECT_IO.  The intended flag, LO_FLAGS_PARTSCAN, has a value of 8 [0].

It looks like this was a regression when deprecating attach_with_partscan[1], which had the correct value of 8.  That same commit introduces this bug.

[0] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/loop.h?h=v5.15#n25
[1] https://github.com/mdaffin/loopdev/commit/1ec98260129771fdb14b064008d857f72e2d5d16