### PR TITLE
Add LoopControl::add

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -211,3 +211,22 @@ fn attach_a_backing_file_with_part_scan(file_size: i64) {
         "there should be only one partition for the device"
     );
 }
+
+#[test]
+fn add_a_loop_device() {
+    let _lock = setup();
+    let dev = std::fs::read_dir("/dev").expect("should be able to open /dev");
+    let device_count = dev
+        .filter(|r| {
+            r.as_ref()
+                .expect("readdir failed")
+                .file_name()
+                .to_string_lossy()
+                .contains("loop")
+        })
+        .count();
+
+    let lc = LoopControl::open().expect("should be able to open the LoopControl device");
+    assert!(lc.add(device_count as u32).is_err()); // EEXIST
+    assert!(lc.add(device_count as u32 + 1).is_ok())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -217,13 +217,15 @@ fn add_a_loop_device() {
     let _lock = setup();
     let dev = std::fs::read_dir("/dev").expect("should be able to open /dev");
     let device_count = dev
-        .filter(|r| {
+        .map(|r| {
             r.as_ref()
                 .expect("readdir failed")
                 .file_name()
                 .to_string_lossy()
-                .contains("loop")
+                .to_string()
         })
+        .filter(|r| r != "loop-control")
+        .filter(|r| r.contains("loop"))
         .count();
 
     let lc = LoopControl::open().expect("should be able to open the LoopControl device");


### PR DESCRIPTION
Add LoopControl::add for adding/creating new loop devices via the LOOP_CTL_ADD ioctl.