### PR TITLE
Add github actions workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu.env]
+BINDGEN_EXTRA_CLANG_ARGS = "-I/usr/aarch64-linux-gnu/include"
+
+[target.aarch64-unknown-linux-musl.env]
+BINDGEN_EXTRA_CLANG_ARGS="-I/usr/local/aarch64-linux-musl/include"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+on: [push, pull_request]
+
+name: loopdev
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-linux-android
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Cross
+        run: cargo install --git https://github.com/cross-rs/cross.git --rev bb3df1b cross
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: check
+          args: --target=${{ matrix.target }}
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install bindgen dependencies
+        run: sudo apt-get install llvm-dev libclang-dev clang
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["loop", "losetup"]
 edition = "2021"
 
 [badges]
-travis-ci = { repository = "serde-rs/serde" }
+build = { status = "https://github.com/mdaffin/loopdev/actions/workflows/ci.yml/badge.svg" }
 
 [features]
 direct_io = []
@@ -24,9 +24,9 @@ libc = "0.2.105"
 bindgen = { version = "0.63.0", default-features = false, features = ["runtime"] }
 
 [dev-dependencies]
-tempfile = "3.2.0"
-lazy_static = "1.4.0"
-serde_json = "1.0.68"
-serde = { version = "1.0.130", features = ["derive"] }
-gpt = "3.0.0"
 glob = "0.3.0"
+gpt = "3.0.0"
+lazy_static = "1.4.0"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+tempfile = "3.2.0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[build]
+pre-build = [
+    # Bindgen dependencies
+    "apt-get update && apt-get install --assume-yes --no-install-recommends libclang-dev",
+]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/mdaffin/loopdev.svg?branch=master)](https://app.travis-ci.com/github/mdaffin/loopdev)
+[![Build Status](https://github.com/mdaffin/loopdev/actions/workflows/ci.yml/badge.svg)](https://github.com/mdaffin/loopdev/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/loopdev.svg)](https://crates.io/crates/loopdev)
 
 # loopdev

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl LoopControl {
                 LOOP_CTL_GET_FREE as IoctlRequest,
             )
         })?;
-        LoopDevice::open(&format!("{}{}", LOOP_PREFIX, dev_num))
+        LoopDevice::open(format!("{}{}", LOOP_PREFIX, dev_num))
     }
 
     /// Add and opens a new loop device.
@@ -144,7 +144,7 @@ impl LoopControl {
                 n as c_int,
             )
         })?;
-        LoopDevice::open(&format!("{}{}", LOOP_PREFIX, dev_num))
+        LoopDevice::open(format!("{}{}", LOOP_PREFIX, dev_num))
     }
 }
 
@@ -298,10 +298,12 @@ impl LoopDevice {
     ///
     /// This function needs to stat the backing file and can fail if there is
     /// an IO error.
+    #[allow(clippy::unnecessary_cast)]
     pub fn major(&self) -> io::Result<u32> {
         self.device
             .metadata()
-            .map(|m| unsafe { libc::major(m.rdev()) as u32 })
+            .map(|m| unsafe { libc::major(m.rdev()) })
+            .map(|m| m as u32)
     }
 
     /// Get the device major number
@@ -310,10 +312,12 @@ impl LoopDevice {
     ///
     /// This function needs to stat the backing file and can fail if there is
     /// an IO error.
+    #[allow(clippy::unnecessary_cast)]
     pub fn minor(&self) -> io::Result<u32> {
         self.device
             .metadata()
-            .map(|m| unsafe { libc::minor(m.rdev()) as u32 })
+            .map(|m| unsafe { libc::minor(m.rdev()) })
+            .map(|m| m as u32)
     }
 
     /// Detach a loop device from its backing file.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -174,7 +174,7 @@ fn detach_a_backing_file(offset: u64, sizelimit: u64, file_size: i64) {
 
 #[test]
 fn attach_a_backing_file_with_part_scan_default() {
-    attach_a_backing_file_with_part_scan(1 * 1024 * 1024);
+    attach_a_backing_file_with_part_scan(1024 * 1024);
 }
 
 fn attach_a_backing_file_with_part_scan(file_size: i64) {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -20,7 +20,7 @@ lazy_static::lazy_static! {
 pub fn create_backing_file(size: i64) -> TempPath {
     let file = NamedTempFile::new().expect("should be able to create a temp file");
     assert!(
-        !(unsafe { fallocate(file.as_raw_fd(), 0, 0, size) } < 0),
+        unsafe { fallocate(file.as_raw_fd(), 0, 0, size) } >= 0,
         "should be able to allocate the temp file: {}",
         io::Error::last_os_error()
     );
@@ -63,7 +63,7 @@ pub fn setup() -> MutexGuard<'static, ()> {
 
 pub fn attach_file(loop_dev: &str, backing_file: &str, offset: u64, sizelimit: u64) {
     if !Command::new("losetup")
-        .args(&[
+        .args([
             loop_dev,
             backing_file,
             "--offset",
@@ -82,7 +82,7 @@ pub fn attach_file(loop_dev: &str, backing_file: &str, offset: u64, sizelimit: u
 pub fn detach_all() {
     std::thread::sleep(std::time::Duration::from_millis(10));
     if !Command::new("losetup")
-        .args(&["-D"])
+        .args(["-D"])
         .status()
         .expect("failed to cleanup existing loop devices")
         .success()
@@ -94,7 +94,7 @@ pub fn detach_all() {
 
 pub fn list_device(dev_file: Option<&str>) -> Vec<LoopDeviceOutput> {
     let mut output = Command::new("losetup");
-    output.args(&["-J", "-l"]);
+    output.args(["-J", "-l"]);
     if let Some(dev_file) = dev_file {
         output.arg(dev_file);
     }


### PR DESCRIPTION
Check compilation and lints for the targets

* aarch64-linux-android
* aarch64-unknown-linux-gnu
* aarch64-unknown-linux-musl
* x86_64-unknown-linux-gnu
* x86_64-unknown-linux-musl

The loopdev crates makes use of bindgen generated code which uses system headers that can be different for different platforms. Ensure that at it at least builds.

Enabling the tests is hard with the current structure of the integration tests and safed for a later PR.