### PR TITLE
Refactor test suite: runner and parallel tests

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+runner = '.cargo/runner-x86_64-unknown-linux-gnu'

--- a/.cargo/runner-x86_64-unknown-linux-gnu
+++ b/.cargo/runner-x86_64-unknown-linux-gnu
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo $@

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ bindgen = { version = "0.60.1", default-features = false, features = ["runtime"]
 
 [dev-dependencies]
 tempfile = "3.2.0"
-lazy_static = "1.4.0"
 serde_json = "1.0.68"
 serde = { version = "1.0.130", features = ["derive"] }
 gpt = "3.0.0"
-glob = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides rust interface with similar functionality to the Linux utility `losetup
 
 ## Examples
 
-```rust
+```no_run
 use loopdev::LoopControl;
 let lc = LoopControl::open().unwrap();
 let ld = lc.next_free().unwrap();

--- a/README.md
+++ b/README.md
@@ -25,12 +25,23 @@ ld.detach().unwrap();
 
 ## Development
 
-### Running The Tests Locally
+### Running tests
 
 Unfortunately the tests require root only syscalls and thus must be run as root.
 There is little point in mocking out these syscalls as I want to test they
 actually function as expected and if they were to be mocked out then the tests
 would not really be testing anything useful.
+
+#### Run tests locally
+
+The tests affect the system of the host machine. A `cargo` runner executes the test
+super user permissions in order to allow access to the loopdev subsystem.
+
+```bash
+cargo test
+```
+
+#### Running the tests in a Vagrant VM
 
 A vagrant file is provided that can be used to create an environment to safely
 run these tests locally as root. With [Vagrant] and [VirtualBox] installed you

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! Default options:
 //!
-//! ```rust
+//! ```no_run
 //! use loopdev::LoopControl;
 //! let lc = LoopControl::open().unwrap();
 //! let ld = lc.next_free().unwrap();
@@ -24,7 +24,7 @@
 //!
 //! Custom options:
 //!
-//! ```rust
+//! ```no_run
 //! # use loopdev::LoopControl;
 //! # let lc = LoopControl::open().unwrap();
 //! # let ld = lc.next_free().unwrap();
@@ -98,7 +98,7 @@ impl LoopControl {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopControl;
     /// let lc = LoopControl::open().unwrap();
     /// let ld = lc.next_free().unwrap();
@@ -174,7 +174,7 @@ impl LoopDevice {
     ///
     /// Attach the device to a file.
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
     /// let mut ld = LoopDevice::open("/dev/loop5").unwrap();
     /// ld.with().part_scan(true).attach("disk.img").unwrap();
@@ -195,7 +195,7 @@ impl LoopDevice {
     ///
     /// Attach the device to a file.
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
     /// let ld = LoopDevice::open("/dev/loop6").unwrap();
     /// ld.attach_file("disk.img").unwrap();
@@ -298,7 +298,7 @@ impl LoopDevice {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
     /// let ld = LoopDevice::open("/dev/loop7").unwrap();
     /// # ld.attach_file("disk.img").unwrap();
@@ -363,7 +363,7 @@ impl LoopDevice {
 ///
 /// Enable partition scanning on attach:
 ///
-/// ```rust
+/// ```no_run
 /// use loopdev::LoopDevice;
 /// let mut ld = LoopDevice::open("/dev/loop6").unwrap();
 /// ld.with()
@@ -375,7 +375,7 @@ impl LoopDevice {
 ///
 /// A 1MiB slice of the file located at 1KiB into the file.
 ///
-/// ```rust
+/// ```no_run
 /// use loopdev::LoopDevice;
 /// let mut ld = LoopDevice::open("/dev/loop5").unwrap();
 /// ld.with()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,213 +1,79 @@
-use loopdev::{LoopControl, LoopDevice};
-use std::path::PathBuf;
+use std::path::Path;
+
+use loopdev::LoopControl;
+
+use crate::util::{
+    create_attach_backing_file, create_backing_file, partition_backing_file, Retries,
+};
 
 mod util;
-use crate::util::{
-    attach_file, create_backing_file, detach_all, list_device, partition_backing_file, setup,
-};
 
 #[test]
 fn get_next_free_device() {
-    let num_devices_at_start = list_device(None).len();
-    let _lock = setup();
-
-    let lc = LoopControl::open().expect("should be able to open the LoopControl device");
-    let ld0 = lc
+    LoopControl::open()
+        .expect("should be able to open the LoopControl device")
         .next_free()
         .expect("should not error finding the next free loopback device");
-
-    assert_eq!(
-        ld0.path(),
-        Some(PathBuf::from(&format!("/dev/loop{}", num_devices_at_start))),
-        "should find the first loopback device"
-    );
 }
 
 #[test]
 fn attach_a_backing_file_default() {
-    attach_a_backing_file(0, 0, 128 * 1024 * 1024);
+    create_attach_backing_file(0, 0, 128 * 1024 * 1024, false);
 }
 
 #[test]
 fn attach_a_backing_file_with_offset() {
-    attach_a_backing_file(128 * 1024, 0, 128 * 1024 * 1024);
+    create_attach_backing_file(128 * 1024, 0, 128 * 1024 * 1024, false);
 }
 
 #[test]
 fn attach_a_backing_file_with_sizelimit() {
-    attach_a_backing_file(0, 128 * 1024, 128 * 1024 * 1024);
+    create_attach_backing_file(0, 128 * 1024, 128 * 1024 * 1024, false);
 }
 
 #[test]
 fn attach_a_backing_file_with_offset_sizelimit() {
-    attach_a_backing_file(128 * 1024, 128 * 1024, 128 * 1024 * 1024);
+    create_attach_backing_file(128 * 1024, 128 * 1024, 128 * 1024 * 1024, false);
 }
 
 // This is also allowed by losetup, not sure what happens if you try to write to the file though.
 #[test]
 fn attach_a_backing_file_with_offset_overflow() {
-    attach_a_backing_file(128 * 1024 * 1024 * 2, 0, 128 * 1024 * 1024);
+    create_attach_backing_file(128 * 1024 * 1024 * 2, 0, 128 * 1024 * 1024, false);
 }
 
 // This is also allowed by losetup, not sure what happens if you try to write to the file though.
 #[test]
 fn attach_a_backing_file_with_sizelimit_overflow() {
-    attach_a_backing_file(0, 128 * 1024 * 1024 * 2, 128 * 1024 * 1024);
-}
-
-fn attach_a_backing_file(offset: u64, sizelimit: u64, file_size: i64) {
-    let _lock = setup();
-
-    let (devices, ld0_path, file_path) = {
-        let lc = LoopControl::open().expect("should be able to open the LoopControl device");
-
-        let file = create_backing_file(file_size);
-        let file_path = file.to_path_buf();
-        let ld0 = lc
-            .next_free()
-            .expect("should not error finding the next free loopback device");
-
-        ld0.with()
-            .offset(offset)
-            .size_limit(sizelimit)
-            .attach(&file)
-            .expect("should not error attaching the backing file to the loopdev");
-
-        let devices = list_device(Some(ld0.path().unwrap().to_str().unwrap()));
-        file.close().expect("should delete the temp backing file");
-
-        (devices, ld0.path().unwrap(), file_path)
-    };
-
-    assert_eq!(
-        devices.len(),
-        1,
-        "there should be only one loopback mounted device"
-    );
-    assert_eq!(
-        devices[0].name.as_str(),
-        ld0_path.to_str().unwrap(),
-        "the attached devices name should match the input name"
-    );
-    assert_eq!(
-        devices[0].back_file.clone().unwrap().as_str(),
-        file_path.to_str().unwrap(),
-        "the backing file should match the given file"
-    );
-    assert_eq!(
-        devices[0].offset,
-        Some(offset),
-        "the offset should match the requested offset"
-    );
-    assert_eq!(
-        devices[0].size_limit,
-        Some(sizelimit),
-        "the sizelimit should match the requested sizelimit"
-    );
-
-    detach_all();
-}
-
-#[test]
-fn detach_a_backing_file_default() {
-    detach_a_backing_file(0, 0, 128 * 1024 * 1024);
-}
-
-#[test]
-fn detach_a_backing_file_with_offset() {
-    detach_a_backing_file(128 * 1024, 0, 128 * 1024 * 1024);
-}
-
-#[test]
-fn detach_a_backing_file_with_sizelimit() {
-    detach_a_backing_file(0, 128 * 1024, 128 * 1024 * 1024);
-}
-
-#[test]
-fn detach_a_backing_file_with_offset_sizelimit() {
-    detach_a_backing_file(128 * 1024, 128 * 1024, 128 * 1024 * 1024);
-}
-
-// This is also allowed by losetup, not sure what happens if you try to write to the file though.
-#[test]
-fn detach_a_backing_file_with_offset_overflow() {
-    detach_a_backing_file(128 * 1024 * 1024 * 2, 0, 128 * 1024 * 1024);
-}
-
-// This is also allowed by losetup, not sure what happens if you try to write to the file though.
-#[test]
-fn detach_a_backing_file_with_sizelimit_overflow() {
-    detach_a_backing_file(0, 128 * 1024 * 1024 * 2, 128 * 1024 * 1024);
-}
-
-fn detach_a_backing_file(offset: u64, sizelimit: u64, file_size: i64) {
-    let num_devices_at_start = list_device(None).len();
-    let _lock = setup();
-
-    {
-        let file = create_backing_file(file_size);
-        attach_file(
-            "/dev/loop5",
-            file.to_path_buf().to_str().unwrap(),
-            offset,
-            sizelimit,
-        );
-
-        let ld0 = LoopDevice::open("/dev/loop5")
-            .expect("should be able to open the created loopback device");
-
-        ld0.detach()
-            .expect("should not error detaching the backing file from the loopdev");
-
-        file.close().expect("should delete the temp backing file");
-    };
-
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    assert_eq!(
-        list_device(None).len(),
-        num_devices_at_start,
-        "there should be no loopback devices mounted"
-    );
-    detach_all();
+    create_attach_backing_file(0, 128 * 1024 * 1024 * 2, 128 * 1024 * 1024, false);
 }
 
 #[test]
 fn attach_a_backing_file_with_part_scan_default() {
-    attach_a_backing_file_with_part_scan(1 * 1024 * 1024);
-}
+    const SIZE: u64 = 10 * 1024 * 1024;
+    let backing_file = create_backing_file(SIZE);
+    partition_backing_file(backing_file.path(), 1024 * 1024);
+    let attached = util::attach_backing_file(backing_file, 0, SIZE, true);
 
-fn attach_a_backing_file_with_part_scan(file_size: i64) {
-    let _lock = setup();
+    // Assume that partion zero is <device>p0.
+    let loop_device_path_partition_1 = attached
+        .loop_device
+        .path()
+        .expect("failed to get path")
+        .to_string_lossy()
+        .chars()
+        .chain("p1".chars())
+        .collect::<String>();
+    let loop_device_path_partition_0 = Path::new(&loop_device_path_partition_1);
 
-    let partitions = {
-        let lc = LoopControl::open().expect("should be able to open the LoopControl device");
+    for _ in Retries::default() {
+        if loop_device_path_partition_0.exists() {
+            return;
+        }
+    }
 
-        let file = create_backing_file(file_size);
-        partition_backing_file(&file, 1024);
-
-        let ld0 = lc
-            .next_free()
-            .expect("should not error finding the next free loopback device");
-
-        ld0.with()
-            .part_scan(true)
-            .attach(&file)
-            .expect("should not error attaching the backing file to the loopdev");
-        let devices = list_device(Some(ld0.path().unwrap().to_str().unwrap()));
-        let partitions = glob::glob(&format!("{}p*", devices[0].name))
-            .unwrap()
-            .map(|entry| entry.unwrap().display().to_string())
-            .collect::<Vec<_>>();
-
-        file.close().expect("should delete the temp backing file");
-
-        partitions
-    };
-
-    assert_eq!(
-        partitions.len(),
-        1,
-        "there should be only one partition for the device"
+    panic!(
+        "failed to find partition {:?}",
+        loop_device_path_partition_0
     );
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,45 +1,137 @@
-use libc::fallocate;
-use serde::{Deserialize, Deserializer};
-use std::{
-    fs::OpenOptions,
-    io,
-    os::unix::io::AsRawFd,
-    path::Path,
-    process::Command,
-    sync::{Arc, Mutex, MutexGuard},
-};
+use gpt::partition::Partition;
+use std::collections::BTreeMap;
+use std::fs;
+use std::{io, os::unix::prelude::AsRawFd, path, process, thread, time};
 
-use tempfile::{NamedTempFile, TempPath};
+use loopdev::{LoopControl, LoopDevice};
+use serde::Deserialize;
+use tempfile::NamedTempFile;
 
-// All tests use the same loopback device interface and so can tread on each others toes leading to
-// racy tests. So we need to lock all tests to ensure only one runs at a time.
-lazy_static::lazy_static! {
-    static ref LOCK: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+/// Attached loop device that is detached on drop.
+pub struct AttachedLoopDevice {
+    /// Backing file
+    pub file: NamedTempFile,
+    /// Loop device
+    pub loop_device: LoopDevice,
 }
 
-pub fn create_backing_file(size: i64) -> TempPath {
+impl Drop for AttachedLoopDevice {
+    fn drop(&mut self) {
+        self.loop_device.detach().expect("failed to detach");
+    }
+}
+
+/// Retry helper with backoff delay.
+pub struct Retries {
+    retries: u32,
+    delay: time::Duration,
+}
+
+impl Default for Retries {
+    fn default() -> Self {
+        Self {
+            retries: 20,
+            delay: time::Duration::from_millis(1),
+        }
+    }
+}
+
+impl Retries {
+    /// Construct a new `Retries` entity with `retries` number of retries
+    /// and a intial backoff duration of `initial_backoff`.
+    pub fn new(retries: u32, initial_backoff: time::Duration) -> Retries {
+        Retries {
+            retries,
+            delay: initial_backoff,
+        }
+    }
+}
+
+impl Iterator for Retries {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.retries == 0 {
+            None
+        } else {
+            self.retries -= 1;
+            thread::sleep(self.delay);
+            self.delay = self.delay * 2;
+            Some(self.retries)
+        }
+    }
+}
+
+/// Loop device meta info from `losetup`.
+#[derive(Deserialize, Debug)]
+pub struct LoopDeviceOutput {
+    /// Device path.
+    pub name: path::PathBuf,
+    /// Size limit
+    #[serde(rename = "sizelimit")]
+    pub size_limit: Option<u64>,
+    /// Offset.
+    pub offset: Option<u64>,
+    /// Backing file path.
+    #[serde(rename = "back-file")]
+    pub backing_file: Option<path::PathBuf>,
+}
+
+/// Query loopback device states with `losetup` and try to find
+/// a device that matches `path`. Returns `None` if the device is not found.
+///
+/// # Panic
+/// Panics if the `losetup` invocation fails or the output is not parseable
+pub fn losetup_find_device(path: impl AsRef<path::Path>) -> Option<LoopDeviceOutput> {
+    #[derive(Deserialize, Debug)]
+    struct LoopDeviceList {
+        loopdevices: Vec<LoopDeviceOutput>,
+    }
+
+    let losetup_stdout = process::Command::new("losetup")
+        .args(["-J", "-l"])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to run losetup")
+        .wait_with_output()
+        .expect("failed to get losetup output")
+        .stdout;
+    let list = serde_json::from_reader::<_, LoopDeviceList>(io::Cursor::new(losetup_stdout))
+        .expect("failed to parse losetup output");
+    list.loopdevices
+        .into_iter()
+        .find(|d| &d.name == path.as_ref())
+}
+
+/// Create a temporary backing file with size `file_size`.
+pub fn create_backing_file(file_size: u64) -> NamedTempFile {
     let file = NamedTempFile::new().expect("should be able to create a temp file");
     assert!(
-        !(unsafe { fallocate(file.as_raw_fd(), 0, 0, size) } < 0),
+        !(unsafe { libc::fallocate(file.as_raw_fd(), 0, 0, file_size as i64) } < 0),
         "should be able to allocate the temp file: {}",
         io::Error::last_os_error()
     );
-    file.into_temp_path()
+    file
 }
 
-pub fn partition_backing_file(backing_file: impl AsRef<Path>, size: u64) {
+/// Write a GPT table to `file` with one partion of size `size`.
+pub fn partition_backing_file(file: impl AsRef<path::Path>, size: u64) {
+    let mut device = fs::OpenOptions::new()
+        .write(true)
+        .open(&file)
+        .expect("file should be writeable");
     gpt::mbr::ProtectiveMBR::new()
-        .overwrite_lba0(&mut OpenOptions::new().write(true).open(&backing_file).unwrap())
+        .overwrite_lba0(&mut device)
         .expect("failed to write MBR");
 
     let mut disk = gpt::GptConfig::new()
         .initialized(false)
         .writable(true)
         .logical_block_size(gpt::disk::LogicalBlockSize::Lb512)
-        .open(backing_file)
+        .open(file)
         .expect("could not open backing file");
 
-    disk.update_partitions(std::collections::BTreeMap::<u32, gpt::partition::Partition>::new())
+    disk.update_partitions(BTreeMap::<u32, Partition>::new())
         .expect("coult not initialize blank partition table");
 
     disk.add_partition(
@@ -55,96 +147,89 @@ pub fn partition_backing_file(backing_file: impl AsRef<Path>, size: u64) {
         .expect("could not write partition table to backing file");
 }
 
-pub fn setup() -> MutexGuard<'static, ()> {
-    let lock = LOCK.lock().unwrap();
-    detach_all();
-    lock
+/// Create a backing file with `file_size` and attach.
+pub fn create_attach_backing_file(
+    offset: u64,
+    sizelimit: u64,
+    file_size: u64,
+    part_scan: bool,
+) -> AttachedLoopDevice {
+    let backing_file = create_backing_file(file_size);
+    attach_backing_file(backing_file, offset, sizelimit, part_scan)
 }
 
-pub fn attach_file(loop_dev: &str, backing_file: &str, offset: u64, sizelimit: u64) {
-    if !Command::new("losetup")
-        .args(&[
-            loop_dev,
-            backing_file,
-            "--offset",
-            &offset.to_string(),
-            "--sizelimit",
-            &sizelimit.to_string(),
-        ])
-        .status()
-        .expect("failed to attach backing file to loop device")
-        .success()
-    {
-        panic!("failed to cleanup existing loop devices")
+/// Attach backing file `backing_file
+pub fn attach_backing_file(
+    backing_file: NamedTempFile,
+    offset: u64,
+    sizelimit: u64,
+    part_scan: bool,
+) -> AttachedLoopDevice {
+    let loop_device = next_attach_retried(backing_file.as_ref(), offset, sizelimit, part_scan)
+        .expect("failed to attach loop device");
+    let loop_device_state =
+        losetup_find_device(&loop_device.path().unwrap()).expect("failed to get device state");
+
+    assert_eq!(
+        loop_device_state
+            .backing_file
+            .expect("missing backing file"),
+        backing_file.as_ref(),
+        "the backing file should match the given file"
+    );
+    assert_eq!(
+        loop_device_state.offset,
+        Some(offset),
+        "the offset should match the requested offset"
+    );
+    assert_eq!(
+        loop_device_state.size_limit,
+        Some(sizelimit),
+        "the sizelimit should match the requested sizelimit"
+    );
+
+    AttachedLoopDevice {
+        file: backing_file,
+        loop_device,
     }
 }
 
-pub fn detach_all() {
-    std::thread::sleep(std::time::Duration::from_millis(10));
-    if !Command::new("losetup")
-        .args(&["-D"])
-        .status()
-        .expect("failed to cleanup existing loop devices")
-        .success()
-    {
-        panic!("failed to cleanup existing loop devices")
+fn next_attach_retried(
+    file: &path::Path,
+    offset: u64,
+    sizelimit: u64,
+    part_scan: bool,
+) -> Result<LoopDevice, &'static str> {
+    let loop_control = LoopControl::open().expect("should be able to open the LoopControl device");
+
+    for _ in Retries::new(10, time::Duration::from_millis(1)) {
+        match loop_control.next_free().and_then(|loop_device| {
+            loop_device
+                .with()
+                .offset(offset)
+                .size_limit(sizelimit)
+                .part_scan(part_scan)
+                .attach(&file)
+                .map(|_| loop_device)
+        }) {
+            Ok(loop_device) => {
+                // Wait for the device file to pop up.
+                for _ in Retries::default() {
+                    if loop_device.path().expect("failed to get path").exists() {
+                        return Ok(loop_device);
+                    }
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => (),
+            Err(e) if e.raw_os_error() == Some(libc::EBUSY) => (),
+            Err(e) => panic!("failed to attach file: {:?}", e),
+        };
     }
-    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    Err("failed to attach. Out of retries")
 }
 
-pub fn list_device(dev_file: Option<&str>) -> Vec<LoopDeviceOutput> {
-    let mut output = Command::new("losetup");
-    output.args(&["-J", "-l"]);
-    if let Some(dev_file) = dev_file {
-        output.arg(dev_file);
-    }
-    let output = output
-        .output()
-        .expect("failed to cleanup existing loop devices");
-
-    if output.stdout.is_empty() {
-        Vec::new()
-    } else {
-        serde_json::from_slice::<ListOutput>(&output.stdout)
-            .unwrap()
-            .loopdevices
-    }
-}
-
-#[derive(Deserialize, Debug)]
-pub struct LoopDeviceOutput {
-    pub name: String,
-    #[serde(rename = "sizelimit")]
-    #[serde(deserialize_with = "deserialize_optional_number_from_string")]
-    pub size_limit: Option<u64>,
-    #[serde(deserialize_with = "deserialize_optional_number_from_string")]
-    pub offset: Option<u64>,
-    #[serde(rename = "back-file")]
-    //#[serde(deserialize_with = "deserialize_nullable_string")]
-    pub back_file: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct ListOutput {
-    pub loopdevices: Vec<LoopDeviceOutput>,
-}
-
-pub fn deserialize_optional_number_from_string<'de, D>(
-    deserializer: D,
-) -> Result<Option<u64>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrInt {
-        String(Option<String>),
-        Number(Option<u64>),
-    }
-
-    match StringOrInt::deserialize(deserializer)? {
-        StringOrInt::String(None) | StringOrInt::Number(None) => Ok(None),
-        StringOrInt::String(Some(s)) => Ok(Some(s.parse().map_err(serde::de::Error::custom)?)),
-        StringOrInt::Number(Some(i)) => Ok(Some(i)),
-    }
+#[test]
+fn retries() {
+    assert_eq!(Retries::new(10, time::Duration::from_nanos(1)).count(), 10);
 }


### PR DESCRIPTION
No way to get vagrant running out of the box so I refactored the test suite...

Instead of relying on the number of devices and assume total ownership of the `loopdev` subsystem in each tests, detach each device in each test. Remove the need for sequential running tests. Some cleanup in the `losetup` output parsing.

@mdaffin Let me know if you're interested in this. This probably also simplifies CI use cases where e.g a simple `cargo test` (or `nextest`) is everything needed. This would be a simple addition to #58. 