### PR TITLE
Increase bindgen dependency lower bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ errno = "0.2.8"
 libc = "0.2.105"
 
 [build-dependencies]
-bindgen = { version = "0.60.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.63.0", default-features = false, features = ["runtime"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
Increase to 0.63. This value was chosen because it is known to succeed in Fedora rawhide and Fedora 38.

0.59.0 bindgen now fails with the following error on these platforms:
 process didn't exit successfully: `/__w/libcryptsetup-rs/libcryptsetup-rs/target/debug/build/loopdev-cd83fd54aaebcba7/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at '"enum_(unnamed_at_/usr/include/linux/loop_h_16_1)" is not a valid Ident', /github/home/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/src/fallback.rs:811:9