### PR TITLE
Switch the vagrant image to an archlinux box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,10 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "archlinux/archlinux"
   config.vm.provision "shell",
     inline: <<-EOS
-      curl https://sh.rustup.rs -sSf | sh -s -- -y
-      apt update && apt install -y gcc clang
+      set -eo
+      pacman -Syu --noconfirm rustup base-devel clang
+      rustup default stable
       fallocate -l 128M /tmp/disk.img
       mv /tmp/disk.img /vagrant/
 EOS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! Default options:
 //!
-//! ```rust
+//! ```no_run
 //! use loopdev::LoopControl;
 //! let lc = LoopControl::open().unwrap();
 //! let ld = lc.next_free().unwrap();
@@ -24,7 +24,7 @@
 //!
 //! Custom options:
 //!
-//! ```rust
+//! ```no_run
 //! # use loopdev::LoopControl;
 //! # let lc = LoopControl::open().unwrap();
 //! # let ld = lc.next_free().unwrap();
@@ -98,7 +98,7 @@ impl LoopControl {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopControl;
     /// let lc = LoopControl::open().unwrap();
     /// let ld = lc.next_free().unwrap();
@@ -125,7 +125,7 @@ impl LoopControl {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopControl;
     /// let lc = LoopControl::open().unwrap();
     /// let ld = lc.add(1).unwrap();
@@ -200,9 +200,9 @@ impl LoopDevice {
     ///
     /// Attach the device to a file.
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
-    /// let mut ld = LoopDevice::open("/dev/loop5").unwrap();
+    /// let mut ld = LoopDevice::open("/dev/loop0").unwrap();
     /// ld.with().part_scan(true).attach("disk.img").unwrap();
     /// # ld.detach().unwrap();
     /// ```
@@ -221,9 +221,9 @@ impl LoopDevice {
     ///
     /// Attach the device to a file.
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
-    /// let ld = LoopDevice::open("/dev/loop6").unwrap();
+    /// let ld = LoopDevice::open("/dev/loop0").unwrap();
     /// ld.attach_file("disk.img").unwrap();
     /// # ld.detach().unwrap();
     /// ```
@@ -324,9 +324,9 @@ impl LoopDevice {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use loopdev::LoopDevice;
-    /// let ld = LoopDevice::open("/dev/loop7").unwrap();
+    /// let ld = LoopDevice::open("/dev/loop0").unwrap();
     /// # ld.attach_file("disk.img").unwrap();
     /// ld.detach().unwrap();
     /// ```
@@ -389,9 +389,9 @@ impl LoopDevice {
 ///
 /// Enable partition scanning on attach:
 ///
-/// ```rust
+/// ```no_run
 /// use loopdev::LoopDevice;
-/// let mut ld = LoopDevice::open("/dev/loop6").unwrap();
+/// let mut ld = LoopDevice::open("/dev/loop0").unwrap();
 /// ld.with()
 ///     .part_scan(true)
 ///     .attach("disk.img")
@@ -401,9 +401,9 @@ impl LoopDevice {
 ///
 /// A 1MiB slice of the file located at 1KiB into the file.
 ///
-/// ```rust
+/// ```no_run
 /// use loopdev::LoopDevice;
-/// let mut ld = LoopDevice::open("/dev/loop5").unwrap();
+/// let mut ld = LoopDevice::open("/dev/loop0").unwrap();
 /// ld.with()
 ///     .offset(1024*1024)
 ///     .size_limit(1024*1024*1024)


### PR DESCRIPTION
The ubuntu one became annoying with snap creating loopback devices breaking the fragile tests. Also disables the doc tests as they are extreamly frigile and break more then they work. `no_run` is used so they should still be built which should be good enough for ensuring they stay working.
