### PR TITLE
Fixes the add_a_loop_device test

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -215,20 +215,8 @@ fn attach_a_backing_file_with_part_scan(file_size: i64) {
 #[test]
 fn add_a_loop_device() {
     let _lock = setup();
-    let dev = std::fs::read_dir("/dev").expect("should be able to open /dev");
-    let device_count = dev
-        .map(|r| {
-            r.as_ref()
-                .expect("readdir failed")
-                .file_name()
-                .to_string_lossy()
-                .to_string()
-        })
-        .filter(|r| r != "loop-control")
-        .filter(|r| r.contains("loop"))
-        .count();
 
     let lc = LoopControl::open().expect("should be able to open the LoopControl device");
-    assert!(lc.add(device_count as u32).is_err()); // EEXIST
-    assert!(lc.add(device_count as u32 + 1).is_ok())
+    assert!(lc.add(1).is_ok());
+    assert!(lc.add(1).is_err());
 }


### PR DESCRIPTION
It tried to count the existing devices by looking at the /dev/loop* files. But these may or may not be free devices so the check for an error on existing device file was failing as the count it came up with could be added. It has been changed to try adding the device twice - the first should succeed and the second should fail. This way around we garuntee the state of the first (assuming it was not added outside of the tests).
